### PR TITLE
fix link & typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,9 @@
 [![npm][npm-image]][npm-url]
 [![downloads][downloads-image]][downloads-url]
 
-[travis-image]: https://img.shields.io/travis/Flet/semistandard.svg?style=flat
-[travis-url]: https://travis-ci.org/Flet/semistandard
-[npm-image]: https://img.shields.io/npm/v/semistandard.svg?style=flat
-[npm-url]: https://npmjs.org/package/semistandard
-[downloads-image]: https://img.shields.io/npm/dm/semistandard.svg?style=flat
-[downloads-url]: https://npmjs.org/package/semistandard
-
 ### One Semicolon for the Dark Lord on his dark throne
 
-All the goodness of [feross/standard](https://github.com/feross/standard) with semicolons sprinkled on top.
+All the goodness of [feross/standard] with semicolons sprinkled on top.
 
 ## Install
 
@@ -23,7 +16,7 @@ npm install semistandard -g
 ## Rules
 Importantly:
 - **semicolons**
-- Check [feross/standard][1] for the rest of the rules.
+- Check [feross/standard] for the rest of the rules.
 
 Sublime users: Try [SublimeLinter-contrib-semistandard](https://github.com/Flet/SublimeLinter-contrib-semistandard) for linting in your editor!
 
@@ -51,7 +44,15 @@ Sublime users: Try [SublimeLinter-contrib-semistandard](https://github.com/Flet/
     lib/torrent.js:950:11: Expected '===' and instead saw '=='.
   ```
 
-3. Never give style feedback on a pull request again! (unless its about semicolons)
+3. Never give style feedback on a pull request again! (unless it's about semicolons)
 
 
-See [feross/standard](https://github.com/feross/standard) for more information. In fact, you should probably just use the `standard` module instead.
+See [feross/standard] for more information. In fact, you should probably just use the `standard` module instead.
+
+[travis-image]: https://img.shields.io/travis/Flet/semistandard.svg?style=flat
+[travis-url]: https://travis-ci.org/Flet/semistandard
+[npm-image]: https://img.shields.io/npm/v/semistandard.svg?style=flat
+[npm-url]: https://npmjs.org/package/semistandard
+[downloads-image]: https://img.shields.io/npm/dm/semistandard.svg?style=flat
+[downloads-url]: https://npmjs.org/package/semistandard
+[feross/standard]: https://github.com/feross/standard


### PR DESCRIPTION
* fixed a missing link to `feross/standard` (was displaying as `[feross/standard][1]`)
* switched to using the same link reference style as the badges for `feross/standard`
* moved link references down to the bottom
* fixed you a grammar, me