### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Error: Use JavaScript Semi-Standard Style
 ### Editor plugins
 
 - **Sublime users**: Try [SublimeLinter-contrib-semistandard](https://github.com/Flet/SublimeLinter-contrib-semistandard) for linting in your editor!
-- **Atom users** - Install [Linter](https://atom.io/packages/linter) and [linter-js-standard](https://atom.io/packages/linter-js-standard)
+- **Atom users** - Install [linter-js-standard](https://atom.io/packages/linter-js-standard)
 
 **Formatting code to Semistandard**
 


### PR DESCRIPTION
`linter-js-standard` doesn't need `linter` installed beforehand as prior. [`59cbc84`](https://github.com/ricardofbarros/linter-js-standard/commit/59cbc84b6e2eb9ab3ec9aac50b77ff23d4d8c9a3)