### PR TITLE
updated semistandard-format to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![travis][travis-image]][travis-url]
 [![npm][npm-image]][npm-url]
 [![downloads][downloads-image]][downloads-url]
+[![bitHound Dependencies](https://www.bithound.io/github/gtanner/semistandard/badges/dependencies.svg)](https://www.bithound.io/github/gtanner/semistandard/master/dependencies/npm)
 
 ### One Semicolon for the Dark Lord on his dark throne
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-standard": "^1.1.0",
     "get-stdin": "^4.0.1",
     "minimist": "^1.1.1",
-    "semistandard-format": "^1.3.6",
+    "semistandard-format": "^2.1.0",
     "standard-engine": "^2.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-config-standard-react": "^1.0.0",
     "eslint-plugin-react": "^3.9.0",
     "eslint-plugin-standard": "^1.1.0",
-    "get-stdin": "^4.0.1",
+    "get-stdin": "^5.0.1",
     "minimist": "^1.1.1",
     "semistandard-format": "^2.1.0",
     "standard-engine": "^2.0.4"


### PR DESCRIPTION
Updated the semistandard-format dep to the latest version to address some issues found with bitHound:

Current: [![bitHound Dependencies](https://www.bithound.io/github/Flet/semistandard/badges/dependencies.svg)](https://www.bithound.io/github/Flet/semistandard/master/dependencies/npm)

With this PR: [![bitHound Dependencies](https://www.bithound.io/github/gtanner/semistandard/badges/dependencies.svg)](https://www.bithound.io/github/gtanner/semistandard/master/dependencies/npm)

The insecure flag was due to a sub dep a few levels down which is why we marked it as a warning rather then an error for the insecure dep.

Didn't clean up any of the other outdated deps to keep this PR simple.

Would you be interested in adding the bitHound badges to your README? I can add them in this PR as well.