### PR TITLE
remove preferGlobal

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "preferGlobal": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/Flet/semistandard.git"


### PR DESCRIPTION
`-g` is typically bad practice, it's usually better to install semistandard locally as a devDependency so that those cloning your repo can also use it without having to set it up manually/globally.