### PR TITLE
Bumped eslint configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "eslint": "^3.4.0",
     "eslint-config-semistandard": "7.0.0",
-    "eslint-config-standard": "6.0.0",
-    "eslint-config-standard-jsx": "3.0.0",
+    "eslint-config-standard": "6.2.0",
+    "eslint-config-standard-jsx": "3.2.0",
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-react": "^6.0.0",
     "eslint-plugin-standard": "^2.0.0",


### PR DESCRIPTION
These version bumps add es7 and es8 support to the parsers:

https://github.com/feross/eslint-config-standard/compare/v6.0.0...v6.2.0
https://github.com/feross/eslint-config-standard-jsx/compare/v3.0.0...v3.2.0

BTW, is there a particular reason these are pinned and not caret-versioned like the rest of the dependencies?