### PR TITLE
Add link to VSCode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Error: Use JavaScript Semi-Standard Style
 
 - **Sublime users**: Try [SublimeLinter-contrib-semistandard](https://github.com/Flet/SublimeLinter-contrib-semistandard) for linting in your editor!
 - **Atom users** - Install [linter-js-standard](https://atom.io/packages/linter-js-standard)
+- **VSCode users** - Install [vscode-standardjs](https://marketplace.visualstudio.com/items?itemName=chenxsan.vscode-standardjs)
 
 ### What you might do if you're clever
 


### PR DESCRIPTION
The latest vscode-standard https://github.com/chenxsan/vscode-standardjs/commit/4bea8b4a35f9d5ec37acbba203c92565cee8c389 add semistandard support, you might want to include a link here  :).